### PR TITLE
Fix bug using EMtree with a correlation matrix

### DIFF
--- a/R/F_inference.R
+++ b/R/F_inference.R
@@ -223,14 +223,16 @@ FitBetaStatic <- function(beta.init, psi, maxIter=50, eps1 = 1e-6,eps2=1e-4, ver
 #' PLN_Y = PLNmodels::PLN(Y~1)
 #' CorY=cov2cor(PLN_Y$model_par$Sigma)
 #' EMtree(PLN.Cor=PLN_Y,verbatim=TRUE, plot=TRUE)
-EMtree<-function(PLN.Cor,  maxIter=30, cond.tol=1e-10, PLN=TRUE, verbatim=TRUE, plot=FALSE){
-  if(PLN){
+EMtree<-function(PLN.Cor,  maxIter=30, cond.tol=1e-10, verbatim=TRUE, plot=FALSE){
+  if(inherits(PLN.Cor, "PLNfit")){
     CorY=cov2cor(PLN.Cor$model_par$Sigma)
-  }else{
+  }else if(inherits(PLN.Cor, "matrix") & nrow(PLN.Cor) == ncol(PLN.Cor)){
     CorY = PLN.Cor
+  }else{
+    stop("PLN.Cor must be a PLN object or a squarred gaussian correlation matrix")
   }
   p = ncol(CorY)
-  n=PLN.Cor$n
+  n = nrow(CorY)
   alpha.psi = Psi_alpha(CorY, n, cond.tol=cond.tol)
   psi = alpha.psi$psi
 

--- a/tests/testthat/test-F_inference.R
+++ b/tests/testthat/test-F_inference.R
@@ -42,6 +42,11 @@ test_that("equiv versions of likelihood", {
 test_that("FitEM", {
   expect_equal(FitEM$logpY[FitEM$maxIter]>FitEM$logpY[FitEM$maxIter-1],TRUE)
 })
+test_that("EMtree() raise an error for PLN.Cor argument", {
+  expect_error(EMtree(covar, plot = FALSE, verbatim = FALSE))
+  expect_error(EMtree(EMtree(cov2cor(PLNobj$model_par$Sigma)[1:9,], plot = FALSE, verbatim = FALSE)))
+  expect_error(EMtree(EMtree(cov2cor(PLNobj$model_par$Sigma)[,1:9], plot = FALSE, verbatim = FALSE)))
+})
 test_that("EMtree.logpY", {
   expect_equal(EM$logpY[EM$maxIter]>EM$logpY[EM$maxIter-1],TRUE)
 })


### PR DESCRIPTION
Hi !

Thanks for your work and this R package 😃 .

There was a small bug when I tried to use correlation matrix in `EMtree()`. If `PLN.Cor` was a matrix the R code tried to look for the vector containing the number of observation, as if it was stored in a `PLN fit` object.

I've added few tests to be sure my fix was working.